### PR TITLE
fix(docs): correct CLI forwarder path and Claude install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Build with Clay in your AI coding agent — skills, MCP tools, and the Clay CLI.
 
 ```
 /plugin marketplace add clay-run/agent-plugins
-/plugin install clay
+/plugin install clay@clay-plugins
 ```
 
 ### Codex
@@ -49,7 +49,8 @@ In **Claude Code** the bundled `clay` CLI is on the agent's PATH automatically. 
 
 ```
 mkdir -p ~/.local/bin
-printf '#!/bin/sh\nexec "<plugin dir>/terracotta/bin/clay" "$@"\n' > ~/.local/bin/clay
+launcher="$(find ~/.codex ~/.cursor ~/.claude -type f -path '*/bin/clay' 2>/dev/null | sort | tail -1)"
+printf '#!/bin/sh\nexec "%s" "$@"\n' "$launcher" > ~/.local/bin/clay
 chmod +x ~/.local/bin/clay
 ```
 


### PR DESCRIPTION
## Summary [AI]
Two low-severity README fixes from the cross-harness plugin bug bash:

- **Manual CLI forwarder**: pointed at `<plugin dir>/terracotta/bin/clay`, but `<plugin dir>` was undefined and harnesses unpack the plugin contents directly (launcher is at `<root>/bin/clay`, no `terracotta/` segment). Replaced with an auto-discovery snippet matching how the `setup` skill resolves it.
- **Claude install command**: use the documented `name@marketplace` form `/plugin install clay@clay-plugins`.

The recommended path (run the `setup` skill) was already correct; these fix only the by-hand fallback and the install snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)