### PR TITLE
docs(oauth): document clay login as the auth path for CLI + MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cp -R agent-plugins/clay ~/.cursor/plugins/local/clay
 
 ## Configuration
 
-Sign in once with `clay login` — it opens a browser to authorize the CLI, and the Clay MCP server (`clay mcp`, a local proxy the plugin registers for you automatically) uses that same session. One login covers both surfaces; there's no key to paste into an environment variable or an MCP config file.
+Sign in once with `clay login` — it opens a browser to authorize the CLI, and the Clay MCP server (`clay mcp`, a local proxy the plugin registers for you automatically) uses that same session.
 
 - **Claude Code / Codex / Cursor** — run `clay login` yourself, or ask the agent to run it for you. It opens your browser, you sign in and pick a workspace, and the CLI stores the session locally. (On Codex/Cursor, if you get `clay: command not found`, see [Using the `clay` CLI](#using-the-clay-cli) below to put it on PATH first.) **Restart the agent afterwards** — it already spawned the `clay mcp` process, so it won't pick up a session created after it started.
 - **Headless / CI** — create a key in Clay under **Settings → Account**, then either pipe it into `clay login --stdin` or export it as `CLAY_API_KEY` (which works without running `clay login` at all). Both are a legacy fallback for non-interactive contexts — prefer `clay login` wherever a browser is available.

--- a/README.md
+++ b/README.md
@@ -32,16 +32,12 @@ cp -R agent-plugins/clay ~/.cursor/plugins/local/clay
 
 ## Configuration
 
-The `clay` CLI and the Clay MCP server both authenticate with a Clay API key. Create one in Clay under **Settings → Account** (the workspace is resolved from the key — there is no workspace id to set), then expose it as `CLAY_API_KEY`:
+Sign in once with `clay login` — it opens a browser to authorize the CLI, and the Clay MCP server (`clay mcp`, a local proxy the plugin registers for you automatically) uses that same session. One login covers both surfaces; there's no key to paste into an environment variable or an MCP config file.
 
-- **Claude Code** — run the bundled `setup` skill, which saves the key and verifies it with `clay whoami`.
-- **Codex / Cursor** — export it in your shell so both the CLI and the MCP server read it:
+- **Claude Code / Codex / Cursor** — run `clay login` yourself, or ask the agent to run it for you. It opens your browser, you sign in and pick a workspace, and the CLI stores the session locally. (On Codex/Cursor, if you get `clay: command not found`, see [Using the `clay` CLI](#using-the-clay-cli) below to put it on PATH first.) **Restart the agent afterwards** — it already spawned the `clay mcp` process, so it won't pick up a session created after it started.
+- **Headless / CI** — create a key in Clay under **Settings → Account**, then either pipe it into `clay login --stdin` or export it as `CLAY_API_KEY` (which works without running `clay login` at all). Both are a legacy fallback for non-interactive contexts — prefer `clay login` wherever a browser is available.
 
-  ```
-  export CLAY_API_KEY="<your key>"
-  ```
-
-Verify with `clay whoami` — exit 0 prints your user and workspace; exit 3 means the key is missing or invalid.
+Verify with `clay whoami` — exit 0 prints your user and workspace; exit 3 means you aren't signed in or the credential is invalid.
 
 ## Using the `clay` CLI
 
@@ -54,7 +50,7 @@ printf '#!/bin/sh\nexec "%s" "$@"\n' "$launcher" > ~/.local/bin/clay
 chmod +x ~/.local/bin/clay
 ```
 
-The CLI still needs `CLAY_API_KEY` in the environment (see above).
+The CLI still needs to be signed in — run `clay login` (see [Configuration](#configuration)).
 
 ## Choosing the right Clay primitive
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ cp -R agent-plugins/clay ~/.cursor/plugins/local/clay
 
 ## Configuration
 
-Sign in once with `clay login` — it opens a browser to authorize the CLI, and the Clay MCP server (`clay mcp`, a local proxy the plugin registers for you automatically) uses that same session.
-
-- **Claude Code / Codex / Cursor** — run `clay login` yourself, or ask the agent to run it for you. It opens your browser, you sign in and pick a workspace, and the CLI stores the session locally. (On Codex/Cursor, if you get `clay: command not found`, see [Using the `clay` CLI](#using-the-clay-cli) below to put it on PATH first.) **Restart the agent afterwards** — it already spawned the `clay mcp` process, so it won't pick up a session created after it started.
-- **Headless / CI** — create a key in Clay under **Settings → Account**, then either pipe it into `clay login --stdin` or export it as `CLAY_API_KEY` (which works without running `clay login` at all). Both are a legacy fallback for non-interactive contexts — prefer `clay login` wherever a browser is available.
+Sign in once with `clay login` — it opens a browser to authorize the CLI, and the Clay MCP server (`clay mcp`, a local proxy the plugin registers for you automatically) uses that same session. Run it yourself, or ask the agent to run it for you: it opens your browser, you sign in and pick a workspace, and the CLI stores the session locally. (On Codex/Cursor, if you get `clay: command not found`, see [Using the `clay` CLI](#using-the-clay-cli) below to put it on PATH first.) **Restart the agent afterwards** — it already spawned the `clay mcp` process, so it won't pick up a session created after it started.
 
 Verify with `clay whoami` — exit 0 prints your user and workspace; exit 3 means you aren't signed in or the credential is invalid.
 

--- a/clay/skills/setup/SKILL.md
+++ b/clay/skills/setup/SKILL.md
@@ -117,14 +117,17 @@ step 1.
 
 Run `clay login`. It opens a browser, the user signs in and picks a workspace, and
 the CLI stores the session locally on disk — used by both the CLI and by `clay mcp`,
-so there's nothing separate to configure for the MCP server. This is safe to run
-directly from an agent's shell tool: the flow waits up to 5 minutes for the browser
-round-trip, so background it if your tool enforces a shorter timeout, and poll
-`clay whoami` until it succeeds:
+so there's nothing separate to configure for the MCP server. The flow waits up to 5
+minutes for the browser round-trip. If your shell tool lets you set a per-command
+timeout, request at least 5 minutes and just run it directly and block on it:
 
 ```bash
-clay login &
+clay login   # request a timeout of at least 5 minutes if your tool supports one
 ```
+
+If your tool's timeout can't be raised past 5 minutes, don't background the
+process — ask the user to run `clay login` in their own terminal instead, then
+poll:
 
 ```bash
 clay whoami; echo "exit_code=$?"   # poll this until exit_code=0

--- a/clay/skills/setup/SKILL.md
+++ b/clay/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Clay setup — authenticate both the `clay` CLI and the Clay MCP server (both are required to use the plugin). Use when `clay` is not found on PATH, `clay whoami` fails, the MCP tools (`read`, `edit_node`) error on auth, CLAY_API_KEY is missing, or the user wants to configure Clay.
+description: Clay setup — authenticate both the `clay` CLI and the Clay MCP server (both are required to use the plugin). Use when `clay` is not found on PATH, `clay whoami` fails, the MCP tools (`read`, `edit_node`) error on auth, the CLI isn't signed in, or the user wants to configure Clay.
 allowed-tools: Bash, Read, Edit, Write
 ---
 
@@ -11,12 +11,16 @@ allowed-tools: Bash, Read, Edit, Write
 1. **The `clay` CLI** — runs tests, searches actions, manages runs.
 2. **The Clay MCP server** — provides the in-editor tools (`read`, `edit_node`, `validate_workflow`, `execute_clay_action`).
 
-Both authenticate with the **same `CLAY_API_KEY`** (the workspace is resolved from the
-key — there is no workspace id to set), but they read it at different times: the CLI
-reads it per command, while the MCP server reads it **once, when the harness launches
-it**. So setting the key is not enough for the MCP — the agent (Claude Code / Codex /
-Cursor) must be **restarted** for the MCP server to pick up a newly-set key, and
-`clay whoami` succeeding does **not** by itself prove the MCP is authenticated.
+Both authenticate the same way: **`clay login`** opens a browser once, and the
+resulting session is shared by the CLI and by `clay mcp` — the local proxy the plugin
+registers as the MCP server, which forwards to Clay using that same session (no
+separate key to hand the MCP server). The catch is *when* each side picks up a
+session: the CLI re-reads it on every command, but `clay mcp` is a long-running
+process the agent's harness spawns once and only resolves the session at startup. So
+signing in is not enough by itself — the agent (Claude Code / Codex / Cursor) must be
+**restarted** for its already-running MCP server to see a session created after it
+launched, and `clay whoami` succeeding does **not** by itself prove the MCP is
+authenticated.
 
 ## 1. Check current state
 
@@ -45,7 +49,7 @@ clay whoami; echo "exit_code=$?"
   step 2, then step 3.
 - **exit_code=3** (`auth_*`) → the CLI works but isn't authenticated. Skip to step 3.
 - **exit_code=5** (`network_*`) → a connection problem. Check `CLAY_API_URL` and the
-  network; do not re-collect the key.
+  network; do not restart the sign-in flow.
 
 ## 2. Put `clay` on your PATH (if it was "command not found", or lacked `mcp`)
 
@@ -109,20 +113,41 @@ Tell the user to fully quit and reopen the agent — a simple retry or reload ma
 not re-spawn the MCP server's process environment — then re-run the check in
 step 1.
 
-**Restart required:** a running Codex or Cursor process resolved its PATH (and,
-for Cursor's MCP server, spawned `clay` via that PATH) before this step ran, so
-it won't see the newly-created `~/.local/bin/clay` entry until it's restarted.
-Tell the user to fully quit and reopen the agent — a simple retry or reload may
-not re-spawn the MCP server's process environment — then re-run the check in
-step 1.
+## 3. Sign in
 
-## 3. Credentials
+Run `clay login`. It opens a browser, the user signs in and picks a workspace, and
+the CLI stores the session locally on disk — used by both the CLI and by `clay mcp`,
+so there's nothing separate to configure for the MCP server. This is safe to run
+directly from an agent's shell tool: the flow waits up to 5 minutes for the browser
+round-trip, so background it if your tool enforces a shorter timeout, and poll
+`clay whoami` until it succeeds:
 
-Create a key in Clay under **Settings → Account**, then make it available as
-`CLAY_API_KEY`:
+```bash
+clay login &
+```
+
+```bash
+clay whoami; echo "exit_code=$?"   # poll this until exit_code=0
+```
+
+If the browser can't be reached from this environment (a headless box, a remote
+sandbox, CI), fall back to a pasted API key — create one in Clay under
+**Settings → Account**, then:
+
+```bash
+echo "<the key>" | clay login --stdin
+```
+
+`clay login --stdin` is refused with `conflict` if a browser session is already
+active — run `clay logout` first to switch. If piping a key in isn't practical
+either (e.g. the key needs to reach a different process's environment than the one
+you're scripting in), export it as `CLAY_API_KEY` instead — the CLI and `clay mcp`
+both fall back to it without requiring `clay login` at all, but treat this as a
+last-resort fallback, not the default:
 
 - **Claude Code** — merge it into `.claude/settings.local.json` (gitignored) under
-  `env`, preserving existing settings:
+  `env`, preserving existing settings, so the spawned MCP server subprocess sees it
+  too:
 
   ```json
   { "env": { "CLAY_API_KEY": "<the key>" } }
@@ -138,6 +163,9 @@ Create a key in Clay under **Settings → Account**, then make it available as
   export CLAY_API_KEY="<the key>"
   ```
 
+Whichever method is used, **restart the agent** afterward — see the note above on
+why a freshly-spawned `clay mcp` process is required to pick up the new session.
+
 ## 4. Verify both surfaces
 
 **CLI:**
@@ -150,6 +178,7 @@ clay whoami; echo "exit_code=$?"
 
 **MCP server:** after restarting the agent, confirm the `clay` MCP server is connected
 and its tools respond — e.g. call `read` on a workflow. If the MCP tools return an auth
-error while `clay whoami` succeeds, the key was set but the agent wasn't restarted (or
-the key isn't visible where the harness launches the MCP server) — set it as in step 3
-and restart again. Setup is complete only when **both** the CLI and the MCP tools work.
+error while `clay whoami` succeeds, you signed in but the agent wasn't restarted (or
+the credential isn't visible where the harness launches the MCP server) — redo the
+restart from step 3 and recheck. Setup is complete only when **both** the CLI and the
+MCP tools work.

--- a/clay/skills/setup/SKILL.md
+++ b/clay/skills/setup/SKILL.md
@@ -130,41 +130,7 @@ clay login &
 clay whoami; echo "exit_code=$?"   # poll this until exit_code=0
 ```
 
-If the browser can't be reached from this environment (a headless box, a remote
-sandbox, CI), fall back to a pasted API key — create one in Clay under
-**Settings → Account**, then:
-
-```bash
-echo "<the key>" | clay login --stdin
-```
-
-`clay login --stdin` is refused with `conflict` if a browser session is already
-active — run `clay logout` first to switch. If piping a key in isn't practical
-either (e.g. the key needs to reach a different process's environment than the one
-you're scripting in), export it as `CLAY_API_KEY` instead — the CLI and `clay mcp`
-both fall back to it without requiring `clay login` at all, but treat this as a
-last-resort fallback, not the default:
-
-- **Claude Code** — merge it into `.claude/settings.local.json` (gitignored) under
-  `env`, preserving existing settings, so the spawned MCP server subprocess sees it
-  too:
-
-  ```json
-  { "env": { "CLAY_API_KEY": "<the key>" } }
-  ```
-
-  Then tell the user to restart so it loads: `/exit`, then `claude --continue`.
-
-- **Codex / Cursor** — export it in the shell profile so both the CLI and the MCP
-  server pick it up, then restart the agent:
-
-  ```bash
-  echo 'export CLAY_API_KEY="<the key>"' >> "$HOME/.zshrc"   # or ~/.bashrc
-  export CLAY_API_KEY="<the key>"
-  ```
-
-Whichever method is used, **restart the agent** afterward — see the note above on
-why a freshly-spawned `clay mcp` process is required to pick up the new session.
+**Restart the agent afterward** so the running MCP server picks up this session.
 
 ## 4. Verify both surfaces
 


### PR DESCRIPTION
## Summary
- The README and the bundled `setup` skill both still documented `CLAY_API_KEY` as the primary way to authenticate the CLI and MCP server. That's superseded — `clay login` (browser OAuth) is the shipped default, and one login covers both the CLI and the `clay mcp` proxy that now backs the plugin's MCP server on all three hosts.
- Updates the README's Configuration and "Using the `clay` CLI" sections to document `clay login` as the only supported auth path.
- Updates `clay/skills/setup/SKILL.md`'s credentials step the same way, since it's what an agent actually runs when auth fails — leaving it undocumented would have the skill contradict the README the moment a user hit an auth error. Also fixes an accidental duplicated "Restart required" paragraph found while auditing the file.
- Drops the `--stdin`/`CLAY_API_KEY` fallback instructions entirely from both files — headless/CI isn't a supported use case for this plugin, so `clay login` is now the only documented way to authenticate.

## Testing
- Docs-only change; no code paths affected. Read through both files end-to-end for internal consistency and cross-checked the described behavior against `apps/cli` (`clay-base`) source: `login.ts`'s help text, `credential.ts`'s `resolveCredential()` fallback order, and `mcp/proxy.ts`'s once-at-startup credential resolution.

[AI] Written by Claude Sonnet 5 based on Derek's request to document the shipped `clay login` OAuth behavior.