### PR TITLE
feat(skills): fix "what can I do with Clay?" framing and use-cases

### DIFF
--- a/clay/skills/clay/SKILL.md
+++ b/clay/skills/clay/SKILL.md
@@ -17,6 +17,35 @@ Whatever you're doing in Clay, work transparently so the user can follow along:
 - **Summarize, don't dump.** Turn raw command output (JSON, `jq`, `diff`) into a
   short takeaway, table, or count. Reserve raw output for when the user asks.
 
+## Answering "what can I do with Clay?"
+
+When a user asks what they can do, you are describing **Clay's product**, not your own
+abilities. Get the framing right:
+
+- **Position it as Clay's, and as theirs to run.** Say "Clay lets you…" and "you can…",
+  not "skills I have," "here's what I can run for you," or "what you can do through me."
+  These are Clay capabilities the user drives; you're just the interface.
+- **Don't call them "playbooks."** The surfaces below (searches, routines, tables,
+  workflows, the CLI, the API) are Clay **primitives and product surfaces** — describe them
+  as what they are. "Playbook" is wrong and confusing.
+- **Don't crown Workflows as the main or "biggest" surface.** They're an **Alpha,
+  last-resort** primitive (see the escalation order below). Lead with **Search** and
+  **Clay-managed functions** — those cover the large majority of GTM tasks. Only mention
+  Workflows as the escape hatch for things a function genuinely can't do.
+- **Lead with concrete, show-off use-cases, not a menu of verbs.** Ground the answer in
+  outcomes the user recognizes. Good examples to draw from (pick a few relevant ones, don't
+  list all):
+  - "Find and enrich decision-makers at a list of target accounts."
+  - "Build a net-new account list matching my ICP (industry, size, region, funding)."
+  - "Enrich a CSV of leads with verified work emails and mobile numbers."
+  - "Score and route inbound signups against our ideal-customer profile."
+  - "Find companies hiring for a role that signals demand for our product."
+  - "Flag job changes among contacts at our customer accounts."
+  - "Query a table and export the rows matching a filter."
+  - "Check how many credits are left, or audit a workflow to cut credit cost."
+
+  Then offer to run one — the goal is a first win, not reciting a catalog.
+
 ## Choosing the right primitive
 
 Clay exposes three core primitives (callable from the plugin/CLI/MCP/API):

--- a/clay/skills/routines/SKILL.md
+++ b/clay/skills/routines/SKILL.md
@@ -31,6 +31,12 @@ clay routines get <id>        # full config, integrations, and input schema
 `clay routines get <id>` is important before running: it shows the routine's **input
 schema** so you know exactly which fields each item needs.
 
+For **function** routines, both `list` and `get` return a `source` (`managed` for a
+Clay-managed default function, `custom` for one built in this workspace) and, for custom
+functions, a `createdBy` (`{ id, name, email }`; `null` for managed ones). Use these to tell
+the user which functions are Clay-managed vs. their team's own, and who authored a custom
+one — e.g. group them by `source`, or note the author when disambiguating similar functions.
+
 ### Create a routine from an existing function or workflow
 
 If no routine exists yet for a function (a table) or a workflow, expose it as a runnable


### PR DESCRIPTION
## Summary [AI]

So that "what can I do with Clay?" reads as Clay's product that the user can run — not as the assistant's own skills — this PR:

- adds framing guidance to the entry-point `clay` skill, and
- points the `routines` skill at the new managed/custom and creator fields.

A product review of the CLI found the "what can you do" answer calls Workflows the "biggest surface", uses voice like "skills I have" and "here's what I can run for you", calls the surfaces "playbooks", and gives a generic verb list. None of that copy is in the skills — grepping this repo (and the whole machine) finds zero matches — so the model is generating it on its own. The skills actually treat Workflows as an Alpha, last-resort primitive. The fix is to steer the answer explicitly.

## Changes [AI]

- `clay/SKILL.md`: adds an "Answering what can I do with Clay?" section that (1) frames capabilities as Clay's, run by the user ("Clay lets you…", "you can…"), not "skills I have"; (2) says not to call the surfaces "playbooks"; (3) says not to crown Workflows as the main or "biggest" surface, and to lead with Search and Clay-managed functions instead; (4) replaces the generic verb list with concrete GTM use-cases to lead with, then offer to run one.
- `routines/SKILL.md`: notes that `clay routines list` / `get` now return a `source` (managed/custom) and `createdBy` for functions, and to use them when listing. This depends on the CLI/API change in clay-run/clay-base#42919; it's harmless before that lands, since the fields are simply absent.

## Test Plan [AI]

- with the updated plugin loaded, start a Clay session and ask "what can you do?"
- see the answer positions capabilities as Clay's ("you can…" / "Clay lets you…"), doesn't call the surfaces "playbooks", doesn't describe Workflows as the biggest/main surface, and leads with concrete use-cases before offering to run one

## Verification [AI]

- copy-only change to two skill markdown files; not exercised against a live session
