### PR TITLE
chore: remove internal publishing details from public README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,30 +61,3 @@ curl -fsSL https://raw.githubusercontent.com/clay-run/agent-plugins/main/GETTING
 
 Then follow the instructions in that fetched document for your agent
 environment.
-
-## Feedback
-
-- **Claude:** `/plugin marketplace add clay-run/agent-plugins` then `/plugin install clay`
-- **Codex:** add the `clay-run/agent-plugins` marketplace, then install `clay`
-- **Cursor:** install from the Cursor marketplace (listing requires a one-time
-  submission at `cursor.com/marketplace/publish`)
-
-Requires **Claude Code v2.1.91+** (the plugin ships `clay` on the Bash PATH via
-`bin/`; in Codex/Cursor, run the `setup` skill to put it on PATH). On first `clay`
-call the `bin/clay` selector reads `bin/cli-version`, downloads that version's binary
-from its `clay-cli-v<version>` release, verifies it against the committed
-`checksums.txt`, and caches it. `clay --version` reports `<cliVersion>+<commit>`, so
-a reported version maps to exact source. The bundled CLI version (`bin/cli-version`)
-and the plugin version are independent; the CLI's npm release is documented in
-`apps/cli/README.md`.
-
-### Publishing credentials
-
-`publish-plugin.yml` authenticates as the **Clay Deploy** GitHub App via the
-client id Iv23liuwmICkPmJbkY1q and the `DEPLOY_APP_PRIVATE_KEY` secret, and fails the job if
-either is missing. The app must be installed on `clay-run/agent-plugins` with
-`Contents: write`.
-
-The `update-sculptor-agent` job needs extra secrets (`ANTHROPIC_AI_API_KEY`,
-`MANAGED_AGENT_CLI_ID`, `NPM_TOKEN`); the workflow's `secrets:` block documents
-each one and its preflight step fails loudly if any is missing.


### PR DESCRIPTION
## Summary [AI]

The README's `Feedback` and `Publishing credentials` sections documented internal CI plumbing — the Clay Deploy GitHub App client id and CI secret names (`DEPLOY_APP_PRIVATE_KEY`, `ANTHROPIC_AI_API_KEY`, `MANAGED_AGENT_CLI_ID`, `NPM_TOKEN`). None of it is user-facing; it leaked into this public repo because the README is synced from `clay-base`'s `plugins/README.md`. This trims everything from the `Feedback` heading onward.

Note: nothing secret was exposed — the client id is a public GitHub App identifier and only secret *names* were listed, not values. This is cleanup, not an incident.

## Follow-up [AI]

This repo's README is generated from `clay-base:plugins/README.md`, so this change will regress on the next plugin publish unless the source is also updated. A companion clay-base PR will rename that source to `PUBLIC_MARKETING_README.md` (published as `README.md`) and strip the internal content there, so team members don't re-add internal notes unaware of the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)