### PR TITLE
Fix public-api skill: use clay-api-key header (not Bearer) and refresh stale search paths

### DIFF
--- a/clay/skills/public-api/SKILL.md
+++ b/clay/skills/public-api/SKILL.md
@@ -12,8 +12,9 @@ in a shell (use the `cli` skill for those).
 ## What it offers
 
 - **Search** — find people or companies in Clay's GTM database using **structured filters**. Discover
-  valid filter fields with `GET /searches/fields?source_type=people` (or `companies`), start a search with
-  `POST /searches`, then page with `POST /searches/{search_id}/next`. The CLI
+  valid filter fields with `GET /search/filters-mode/fields?source_type=people` (or `companies`), start a
+  search with `POST /search/filters-mode`, then page through the results (see the API reference for the
+  exact pagination route). The CLI
   equivalent is `clay search` — see the `search` skill. Prefer the CLI for one-off searches
 - **Tables** — structured queries against Clay tables.
 - **Routines / batches** — async routine and batch runs.
@@ -28,9 +29,17 @@ clay api-keys create --name "<name>"   # → { ..., "apiKey": "<secret>" }
 ```
 
 CLI-created keys are always scoped to the public API. The `apiKey` secret is returned
-**only once**, at creation — store it immediately; it can't be retrieved later. Send it
-as a Bearer token against `https://api.clay.com/public/v0`. Manage existing keys with
+**only once**, at creation — store it immediately; it can't be retrieved later. Send it in the
+`clay-api-key` request header against `https://api.clay.com/public/v0` — **not** as a `Bearer`
+token (a `Bearer` header returns 401). Manage existing keys with
 `clay api-keys list | update | delete`.
+
+Smoke-test the key:
+
+```bash
+curl -H "clay-api-key: $CLAY_API_KEY" https://api.clay.com/public/v0/me
+# → { "user": {...}, "workspace": {...} }
+```
 
 ## Reference
 


### PR DESCRIPTION
## Summary

`clay/skills/public-api/SKILL.md` tells agents to send the API key **"as a Bearer token against `https://api.clay.com/public/v0`"**. That returns **401 on every endpoint**. The correct scheme, per Clay's own docs (https://developers.clay.com/public-api/authentication.md), is the **`clay-api-key: <key>`** header.

An agent following the skill as written burns its retries on 401s and concludes the key is bad.

## Verified reproduction

Key minted with `clay api-keys create` (repo state: `main` as of 2026-07-10):

```bash
# As the skill instructs — fails:
curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $KEY" \
  https://api.clay.com/public/v0/me       # -> 401

# Per developers.clay.com — works:
curl -s -o /dev/null -w "%{http_code}" -H "clay-api-key: $KEY" \
  https://api.clay.com/public/v0/me       # -> 200  {"user":...,"workspace":...}
```

## Secondary fix: stale Search endpoint paths

The skill's "What it offers" section listed old routes. Verified against the live API:

| Skill (old) | Result | Current | Result |
|---|---|---|---|
| `GET /searches/fields?source_type=companies` | 404 | `GET /search/filters-mode/fields?source_type=companies` | 200 (30 fields) |
| `POST /searches` | 404 | `POST /search/filters-mode` | 400 (path exists, wants a body) |

Pagination route left to the API reference rather than asserting an unverified path.

## Changes (one file)

- **Auth:** replace the `Bearer` sentence with the `clay-api-key` header + a `/v0/me` smoke-test.
- **Search paths:** update the `fields` and start-search routes to the verified `/search/filters-mode/...` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)