### PR TITLE
fix(clay): clear error for native Windows instead of generic OS failure

### DIFF
--- a/clay/bin/clay
+++ b/clay/bin/clay
@@ -41,6 +41,7 @@ arch="$(uname -m)"
 case "$os" in
   Darwin) os="darwin" ;;
   Linux) os="linux" ;;
+  MINGW* | MSYS* | CYGWIN*) die "validation_error" "clay: native Windows is not supported yet (no Windows CLI binary is published) — run Claude Code, Codex, or Cursor inside WSL instead" 2 ;;
   *) die "validation_error" "clay: unsupported OS: $os" 2 ;;
 esac
 case "$arch" in


### PR DESCRIPTION
Git Bash/MSYS/Cygwin report uname -s as MINGW64_NT-*, MSYS_NT-*, or CYGWIN_NT-*, which fell through to the generic "unsupported OS" error. No Windows CLI binary is published yet, so point users at WSL instead.