### PR TITLE
feat: add Droid as a supported agent

### DIFF
--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "clay-plugins",
+  "description": "Official Clay plugins for Droid",
+  "owner": {
+    "name": "Clay"
+  },
+  "plugins": [
+    {
+      "name": "clay",
+      "source": "./clay",
+      "description": "Build with Clay in Droid"
+    }
+  ]
+}

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -42,9 +42,22 @@ see [Run the `setup` skill](#run-the-setup-skill) below. Once setup finishes, de
 (`rm -rf /tmp/clay-agent-plugins`) — whichever path the skill picked already copied what it
 needs to a permanent location.
 
+### Droid
+
+```
+droid plugin marketplace add https://github.com/clay-run/agent-plugins
+droid plugin install clay@agent-plugins
+```
+
+The marketplace name is derived from the repo (`agent-plugins`); confirm the exact
+`clay@<marketplace>` id with `droid plugin marketplace list`, or install interactively from
+the `/plugins` UI (Browse tab). Droid loads the plugin's skills and MCP server; like Codex and
+Cursor it invokes a bare `clay`, so run the **`setup` skill** below to put `clay` on PATH and
+sign in.
+
 ## Run the `setup` skill
 
-Once installed, run the bundled **`setup` skill** now, in this session, before anything else below. It puts `clay` on PATH (needed on Codex and Cursor), signs you in, and verifies both the CLI and the MCP server work.
+Once installed, run the bundled **`setup` skill** now, in this session, before anything else below. It puts `clay` on PATH (needed on Codex, Cursor, and Droid), signs you in, and verifies both the CLI and the MCP server work.
 
 **Important — restarting your agent afterward is not optional:** `clay mcp` resolves its session once at startup, so an already-running MCP server won't see a sign-in that happened after it launched — skipping the restart is the most common reason `clay login` looks like it worked but the MCP tools still fail. How you restart is platform-specific; see the skill for the exact steps.
 
@@ -52,7 +65,7 @@ Once installed, run the bundled **`setup` skill** now, in this session, before a
 - If it doesn't, or the skill doesn't show up right after installing (some platforms don't register a newly installed plugin until restarted), locate `SKILL.md` yourself and follow it like a runbook:
 
   ```
-  find ~/.codex ~/.cursor ~/.claude ~/.config -type f -path '*/skills/setup/SKILL.md' 2>/dev/null | sort | tail -n1
+  find ~/.codex ~/.cursor ~/.claude ~/.factory ~/.config -type f -path '*/skills/setup/SKILL.md' 2>/dev/null | sort | tail -n1
   ```
 
   Read the path that prints and carry out its steps directly.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <strong>Build with Clay in your AI coding agent</strong> — skills, MCP tools, and the <code>clay</code>
-  CLI, for Claude Code, Codex, and Cursor.
+  CLI, for Claude Code, Codex, Cursor, and Droid.
 </p>
 
 <p align="center">
@@ -16,7 +16,7 @@
 
 Clay is a go-to-market data and automation platform — search for companies and
 people, run enrichment routines, and query tables, all from natural language.
-This repo is the plugin marketplace for `clay`: one plugin source, three
+This repo is the plugin marketplace for `clay`: one plugin source, four
 coding-agent targets, sharing one set of skills and one CLI.
 
 ## Example

--- a/clay/.factory-plugin/plugin.json
+++ b/clay/.factory-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "clay",
+  "description": "Build with Clay in Droid",
+  "version": "2.1.13",
+  "author": { "name": "Clay" }
+}

--- a/clay/skills/setup/SKILL.md
+++ b/clay/skills/setup/SKILL.md
@@ -62,7 +62,7 @@ clay whoami; echo "exit_code=$?"
 
 - **`clay: command not found`** (or exit 127) → the CLI isn't on your PATH. On Cursor, do
   step 2 first (it decides where the plugin's files permanently live); then do step 3, then
-  step 4. On Claude Code and Codex, skip step 2 and go straight to step 3, then step 4.
+  step 4. On Claude Code, Codex, and Droid, skip step 2 and go straight to step 3, then step 4.
   Exception: exit 127 with a JSON envelope on stderr saying `no bundled launcher found` is
   the forwarder from a previous setup reporting that the plugin cache itself is gone —
   reinstalling the forwarder won't help; tell the user to reinstall the Clay plugin instead
@@ -87,8 +87,8 @@ fallback) — then continue to step 3 below.
 ## 3. Put `clay` on your PATH (if it was "command not found", lacked `mcp`, or is an outdated version)
 
 Claude Code adds the plugin's `bin/` to PATH automatically, so this step is only
-needed in Codex and Cursor, or when another `clay` install is shadowing the bundled
-one.
+needed in Codex, Cursor, and Droid, or when another `clay` install is shadowing the
+bundled one.
 
 The plugin bundles the CLI launcher at `bin/clay` in the plugin root; it downloads
 and checksum-verifies the real binary on first use. The launcher is version-stable
@@ -98,10 +98,10 @@ just needs to point at the newest launcher on disk.
 Install a small forwarder onto your PATH (in `~/.local/bin`) that resolves the
 newest bundled launcher **at runtime** rather than baking in one absolute path.
 This is what lets it survive plugin updates (which install a new version directory)
-and work no matter which agent (Claude Code / Codex / Cursor) installed the plugin.
+and work no matter which agent (Claude Code / Codex / Cursor / Droid) installed the plugin.
 It picks the most-recently-modified launcher — an install-time heuristic that works
 across both version-named cache dirs (Claude/Codex) and commit-hash-named ones
-(Cursor). If one agent's cache lags behind another's, the freshest install wins, so
+(Cursor/Droid). If one agent's cache lags behind another's, the freshest install wins, so
 the CLI can briefly trail the newest pin until the caches converge — every launcher
 is self-contained, so it still runs a valid checksum-verified CLI.
 
@@ -116,6 +116,7 @@ sh -c 'ls -1dt \
   "${CODEX_HOME:-$HOME/.codex}"/plugins/cache/*/clay/*/bin/clay \
   "$HOME"/.cursor/plugins/cache/*/clay/*/bin/clay \
   "$HOME"/.cursor/plugins/local/clay/bin/clay \
+  "${FACTORY_CONFIG_DIR:-$HOME/.factory}"/plugins/cache/*/clay/*/bin/clay \
   "$HOME"/.config/clay-plugin/clay/bin/clay \
   2>/dev/null | head -n1'
 ```
@@ -135,15 +136,16 @@ mkdir -p "$HOME/.local/bin"
 cat > "$HOME/.local/bin/clay" <<'EOF'
 #!/bin/sh
 # Resolve the newest bundled clay launcher at runtime so this forwarder survives
-# plugin version bumps and works whichever agent (Claude/Codex/Cursor) installed it.
-# CLAUDE_CONFIG_DIR and CODEX_HOME relocate those agents' state roots (and with
-# them the plugin cache), so honor them when set — they expand here at runtime,
-# from the invoking process's environment.
+# plugin version bumps and works whichever agent (Claude/Codex/Cursor/Droid) installed it.
+# CLAUDE_CONFIG_DIR, CODEX_HOME, and FACTORY_CONFIG_DIR relocate those agents' state
+# roots (and with them the plugin cache), so honor them when set — they expand here
+# at runtime, from the invoking process's environment.
 launcher="$(ls -1dt \
   "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/*/clay/*/bin/clay \
   "${CODEX_HOME:-$HOME/.codex}"/plugins/cache/*/clay/*/bin/clay \
   "$HOME"/.cursor/plugins/cache/*/clay/*/bin/clay \
   "$HOME"/.cursor/plugins/local/clay/bin/clay \
+  "${FACTORY_CONFIG_DIR:-$HOME/.factory}"/plugins/cache/*/clay/*/bin/clay \
   "$HOME"/.config/clay-plugin/clay/bin/clay \
   2>/dev/null | head -n1)"
 # Match the launcher's bootstrap-failure contract: JSON envelope on stderr and a
@@ -235,6 +237,11 @@ actually respawns the MCP server depends on where you're running:
   enough. If the MCP tools still error, use Cmd/Ctrl+Shift+P →
   **Developer: Reload Window**; if that still doesn't pick it up, fully quit
   and reopen Cursor.
+- **Droid (CLI):** Droid spawns each plugin's MCP server once at startup, so a
+  new session in the *same* running process won't reconnect Clay. Exit the
+  process (`/exit` or Ctrl+C) and run `droid` again; if a background
+  `droid daemon` is running, restart it too. Confirm with
+  `droid mcp list` — the `clay` server should read `connected`.
 
 ## 5. Verify both surfaces
 


### PR DESCRIPTION
## What

Adds [Droid](https://factory.ai) as a first-class supported agent, alongside Claude Code, Codex, and Cursor.

Droid is [Claude-Code-plugin compatible](https://docs.factory.ai) and discovers a plugin's `skills/` and `mcp.json` by fixed filename, so making it work needs only a native marketplace + plugin manifest plus docs.

## Changes

- **`.factory-plugin/marketplace.json`** — Droid marketplace manifest (`clay-plugins`, one plugin `clay` sourced from `./clay`).
- **`clay/.factory-plugin/plugin.json`** — minimal plugin manifest (name/description/version/author). No `mcpServers`/`hooks`/`skills` path fields: Droid loads `clay/mcp.json` (the same bare-`clay` config Cursor uses) and `clay/skills/` automatically.
- **`GETTING_STARTED.md`** — new **Droid** install section (`droid plugin marketplace add …` / `droid plugin install clay@agent-plugins`) and PATH/setup-skill notes.
- **`README.md`** — tagline + "one plugin source, four coding-agent targets".
- **`clay/skills/setup/SKILL.md`** — the PATH forwarder now also searches Droid's plugin cache (`${FACTORY_CONFIG_DIR:-$HOME/.factory}/plugins/cache/*/clay/*/bin/clay`), and there's a Droid entry in the command-not-found guidance and the "restart the agent" section.

## Notes

- **No hooks for Droid** — unlike the other agents, this intentionally ships no approval hooks; the `approve-*.sh` scripts are unchanged.
- Since Droid's `mcp.json` invokes a bare `clay` (shared with Cursor), users run the bundled `setup` skill to put `clay` on PATH and sign in, then restart Droid so the MCP server reconnects.

## Verification

Installed locally and confirmed end to end:

- `droid plugin marketplace add … && droid plugin install clay@…` installs the plugin.
- After `clay login`, `droid mcp list` shows `clay  stdio  connected`.