### PR TITLE
clay: fail fast with a clear WSL pointer on native Windows

### DIFF
--- a/clay/bin/clay
+++ b/clay/bin/clay
@@ -41,6 +41,8 @@ arch="$(uname -m)"
 case "$os" in
   Darwin) os="darwin" ;;
   Linux) os="linux" ;;
+  MINGW64_NT-* | MINGW32_NT-* | MSYS_NT-* | CYGWIN_NT-*)
+    die "validation_error" "clay: native Windows is not supported (detected $os); run Claude Code / this CLI inside WSL instead, where the Linux binary works" 2 ;;
   *) die "validation_error" "clay: unsupported OS: $os" 2 ;;
 esac
 case "$arch" in


### PR DESCRIPTION
bin/clay's OS detection now recognizes Git Bash/MSYS/Cygwin's uname -s output (MINGW64_NT-*, MINGW32_NT-*, MSYS_NT-*, CYGWIN_NT-*), which previously fell through to a generic 'unsupported OS: $os' error. It now fails fast pointing users at WSL as the supported path, using the same validation_error category/exit code as the existing OS/arch checks.

Addresses the "at minimum a clear error message" fallback requested in #9. No Windows CLI binary is published (checksums.txt only lists darwin-arm64, darwin-x64, linux-arm64, linux-x64), and building one is a change to the clay CLI's own build/release pipeline, not this plugin repo, so this does not add native Windows support.